### PR TITLE
Update gulpfile.js to Move Font Files to .tmp/font

### DIFF
--- a/templates/app/gulpfile.js
+++ b/templates/app/gulpfile.js
@@ -75,11 +75,8 @@ gulp.task('jshint', function () {
  * CSS
  */
 gulp.task('clean-css', function (done) {
-  rimraf([
-      './.tmp/css',
-      './.tmp/fonts'
-      ], 
-      done);
+  rimraf('./.tmp/css', function() {});
+  rimraf('./.tmp/fonts', done);
 });
 
 gulp.task('fonts', function () {

--- a/templates/app/gulpfile.js
+++ b/templates/app/gulpfile.js
@@ -78,7 +78,17 @@ gulp.task('clean-css', function (done) {
   rimraf('./.tmp/css', done);
 });
 
-gulp.task('styles', ['clean-css'], function () {
+gulp.task('fonts', function () {
+  return gulp.src([
+    './bower_components/**/*.eot',
+    './bower_components/**/*.svg',
+    './bower_components/**/*.ttf',
+    './bower_components/**/*.woff',
+    './bower_components/**/*.woff2'
+  ]).pipe(gulp.dest('./.tmp/fonts/'));
+});
+
+gulp.task('styles', ['clean-css', 'fonts'], function () {
   return gulp.src([
     './src/app/**/*.<%= styleData.extension %>',
     '!./src/app/**/_*.<%= styleData.extension %>'

--- a/templates/app/gulpfile.js
+++ b/templates/app/gulpfile.js
@@ -81,11 +81,9 @@ gulp.task('clean-css', function (done) {
 
 gulp.task('fonts', function () {
   return gulp.src([
-    './bower_components/**/*.eot',
-    './bower_components/**/*.svg',
-    './bower_components/**/*.ttf',
-    './bower_components/**/*.woff',
-    './bower_components/**/*.woff2'
+    './bower_components/bootstrap/fonts/**/*',
+    './bower_components/bootstrap-sass/assets/fonts/**/*',
+    './bower_components/fontawesome/fonts/**/*'
   ]).pipe(gulp.dest('./.tmp/fonts/'));
 });
 

--- a/templates/app/gulpfile.js
+++ b/templates/app/gulpfile.js
@@ -75,7 +75,11 @@ gulp.task('jshint', function () {
  * CSS
  */
 gulp.task('clean-css', function (done) {
-  rimraf('./.tmp/css', done);
+  rimraf([
+      './.tmp/css',
+      './.tmp/fonts'
+      ], 
+      done);
 });
 
 gulp.task('fonts', function () {


### PR DESCRIPTION
Fixes an issue when vender css files being piped to .tmp directory breaks relative links