### PR TITLE
add no-boilerplate project checkbox

### DIFF
--- a/tasks/app.js
+++ b/tasks/app.js
@@ -46,20 +46,25 @@
                     type: 'confirm',
                     name: 'middleware',
                     message: 'Do you want to use middleware for proxy support?',
-                    default: true
+                    default: false
                 }, {
                     type: 'checkbox',
                     name: 'example',
                     message: 'Please select the examples that needs to be included:',
                     choices: [{
+                            name: 'Empty AngularJS with no boilerplate code and external libraries',
+                            value: 'empty',
+                            checked: true
+                        },
+                        {
                             name: 'A Simple TODO application to demo the AngularJS',
                             value: 'todo',
-                            checked: true
+                            checked: false
                         },
                         new inquirer.Separator("These require server side REST calls and it is highly recommended to use the middleware support:"), {
                             name: 'A Simple example to show how to make server call for non persistance service calls (heat)',
                             value: 'heat',
-                            checked: true
+                            checked: false
                         }
                     ]
                 }],
@@ -67,6 +72,7 @@
                     //Hande for user response
                     answers.nameDashed = _.slugify(answers.name);
                     answers.modulename = _.camelize(answers.nameDashed);
+                    answers.cleanConfig =  answers.example.indexOf('empty') != -1;
                     var files = [__dirname + '/../templates/app/**'];
                     var exclude = _.xor(examples, answers.example);
                     _.each(exclude, function(choice) {

--- a/templates/app/bower.json
+++ b/templates/app/bower.json
@@ -20,7 +20,7 @@
   ],
   "dependencies": {
     "angular": "~1.4.0",
-    "angular-route": "~1.2.14",
+    "angular-route": "~1.2.14"<%if(!cleanConfig){%>,
     "bootstrap": "~3.3.1",
     "angular-resource": "~1.3.10",
     "angular-ui-grid": "~3.0.0-rc.19",
@@ -28,11 +28,11 @@
     "fontawesome": "~4.3.0",
     "less": "~2.4.0",
     "angular-bootstrap-slider": "~0.1.1",
-    "angulartics": "~0.17.2"
-  },
+    "angulartics": "~0.17.2"<%}%>
+  }<%if(!cleanConfig){%>,
   "devDependencies": {
     "angular-mocks": "~1.2.29"
-  },
+  }<%}%>,
   "resolutions": {
     "angular": "~1.4.0"
   }

--- a/templates/app/package.json
+++ b/templates/app/package.json
@@ -39,7 +39,10 @@
     "gulp-uglify": "~0.3.0",
     "gulp-htmlmin": "~0.1.2",
     "gulp-ng-html2js": "~0.1.7",
-    "gulp-ng-annotate": "~0.2.0",
+    "gulp-connect": "^2.2.0",
+    "gulp-ng-annotate": "~0.2.0"
+    <% if (!cleanConfig) { %>,
+    "karma": "~0.12.16",
     "gulp-karma": "~0.0.4",
     "karma-chai": "~0.1.0",
     "karma-mocha": "~0.1.3",
@@ -47,9 +50,8 @@
     "karma-phantomjs-launcher": "~0.1.4",
     "karma-script-launcher": "~0.1.0",
     "karma-chrome-launcher": "~0.1.4",
-    "karma-firefox-launcher": "~0.1.3",
-    "gulp-connect": "^2.2.0",
-    "karma": "~0.12.16"<% if (middleware) { %>,
+    "karma-firefox-launcher": "~0.1.3"<% } %>
+     <% if (middleware) { %>,
     "proxy-middleware": "^0.9.0",
     "url": "^0.10.2",
     "lodash": "^3.0.0"<% } %>

--- a/templates/app/src/app/app.js
+++ b/templates/app/src/app/app.js
@@ -2,7 +2,7 @@
     'use strict';
     //This is the basic entry point of the applicaion
     angular.module('<%= modulename %>', [
-        'ngRoute', 'ngResource'<% if (exampleSettings['todo'] == 'todo') { %>,
+        'ngRoute'<%if (!cleanConfig) { %>, 'ngResource' <% } %> <% if (exampleSettings['todo'] == 'todo') { %>,
         '<%= modulename %>.todo'<% } %><% if (exampleSettings['heat'] == 'heat') { %>,
         '<%= modulename %>.heat'<% } %>
     ]);


### PR DESCRIPTION
Hi I've seen that was missing the possibility to create a clean project without boilerplate code and libraries (bootstrap, font-awesome etc).
So I've just edited the app templates to have this possibility, adding a new variable called `cleanConfig` that is set to true if chosen and that remove unnecessary files from the app template.
Hope it could be merged, as this is very useful for us since we build our code without bootstrap/font-awesome etc.
